### PR TITLE
Create tokens API

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "clean": "rimraf dist",
     "test": "yarn jest",
     "semantic-release": "semantic-release",
-    "benchmark": "node scripts/benchmark.js"
+    "benchmark": "node scripts/benchmark.js",
+    "prepublish": "yarn build"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonami",
-  "version": "0.4.0-beta.6",
+  "version": "0.4.0-beta.7",
   "source": "src/tonami.ts",
   "main": "./dist/tonami.js",
   "module": "./dist/tonami.module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonami",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "source": "src/tonami.ts",
   "main": "./dist/tonami.js",
   "module": "./dist/tonami.module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonami",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "source": "src/tonami.ts",
   "main": "./dist/tonami.js",
   "module": "./dist/tonami.module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonami",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "source": "src/tonami.ts",
   "main": "./dist/tonami.js",
   "module": "./dist/tonami.module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonami",
-  "version": "0.4.0-beta.5",
+  "version": "0.4.0-beta.6",
   "source": "src/tonami.ts",
   "main": "./dist/tonami.js",
   "module": "./dist/tonami.module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonami",
-  "version": "0.3.2",
+  "version": "0.4.0-beta.0",
   "source": "src/tonami.ts",
   "main": "./dist/tonami.js",
   "module": "./dist/tonami.module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonami",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "source": "src/tonami.ts",
   "main": "./dist/tonami.js",
   "module": "./dist/tonami.module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonami",
-  "version": "0.4.0-beta.4",
+  "version": "0.4.0-beta.5",
   "source": "src/tonami.ts",
   "main": "./dist/tonami.js",
   "module": "./dist/tonami.module.js",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "clean": "rimraf dist",
     "test": "yarn jest",
     "semantic-release": "semantic-release",
-    "benchmark": "node scripts/benchmark.js",
-    "prepublish": "yarn build"
+    "benchmark": "node scripts/benchmark.js"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonami",
-  "version": "0.4.0-beta.7",
+  "version": "0.4.0",
   "source": "src/tonami.ts",
   "main": "./dist/tonami.js",
   "module": "./dist/tonami.module.js",

--- a/src/__tests__/createTokens.spec.tsx
+++ b/src/__tests__/createTokens.spec.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { createTokens } from "../createTokens";
+import { sheet } from "../sheet";
+import { styled } from "../styled";
+
+beforeEach(() => {
+  sheet.reset();
+});
+
+describe("createTokens", () => {
+  test("should have a toStyleObject function property", () => {
+    const theme = createTokens({ blue: "#0000ff", inner: { test: "red" } });
+    expect(typeof theme.toStyleObject).toEqual("function");
+    expect(theme.toStyleObject()).toEqual({
+      "--blue": "#0000ff",
+      "--inner-test": "red",
+    });
+    expect(theme.blue).toEqual("var(--blue)");
+    expect(theme.inner.test).toEqual("var(--inner-test)");
+    expect(JSON.stringify(theme)).toEqual(
+      '{"blue":"var(--blue)","inner":{"test":"var(--inner-test)"}}'
+    );
+  });
+
+  test("returns a Global element for automatic use", () => {
+    const theme = createTokens({ primary: "blue", secondary: "red" });
+    const { Tokens } = theme;
+    const Test = styled.span({ color: theme.primary });
+    render(
+      <>
+        <Tokens />
+        <Test>Hello World</Test>
+      </>
+    );
+    expect(sheet.rules).toContain(
+      "html { --primary: blue; --secondary: red; }"
+    );
+    expect(sheet.rules).toContain(
+      ".TA3f70c1ae.TAc22dd76 { color: var(--primary); }"
+    );
+  });
+
+  test("can create dynamic token function", () => {
+    let light = { fg: "black", bg: "white" };
+    let dark = { fg: "white", bg: "black" };
+    let themes = { light, dark };
+    let theme = createTokens(light);
+    let { createDynamicTokens } = theme;
+    const DynamicTokens = createDynamicTokens<{ $mode: keyof typeof themes }>(
+      ({ $mode }) => themes[$mode]
+    );
+    const { rerender } = render(<DynamicTokens $mode="light" />);
+    expect(sheet.rules).toContain("html { --fg: black; --bg: white; }");
+    rerender(<DynamicTokens $mode="dark" />);
+    expect(sheet.rules).not.toContain("html { --fg: black; --bg: white; }");
+    expect(sheet.rules).toContain("html { --fg: white; --bg: black; }");
+    expect(theme.fg).toEqual("var(--fg)");
+  });
+});

--- a/src/__tests__/createTokens.spec.tsx
+++ b/src/__tests__/createTokens.spec.tsx
@@ -37,7 +37,7 @@ describe("createTokens", () => {
       "html { --primary: blue; --secondary: red; }"
     );
     expect(sheet.rules).toContain(
-      ".TA3f70c1ae.TAc22dd76 { color: var(--primary); }"
+      ".TA4190736c.TAf46b735c { color: var(--primary); }"
     );
   });
 

--- a/src/__tests__/createTokens.spec.tsx
+++ b/src/__tests__/createTokens.spec.tsx
@@ -36,9 +36,12 @@ describe("createTokens", () => {
     expect(sheet.rules).toContain(
       "html { --primary: blue; --secondary: red; }"
     );
-    expect(sheet.rules).toContain(
-      ".TA4190736c.TAf46b735c { color: var(--primary); }"
-    );
+    expect(sheet.rules).toMatchInlineSnapshot(`
+      Array [
+        ".TA3f70c1ae.TAc22dd76 { color: var(--primary); }",
+        "html { --primary: blue; --secondary: red; }",
+      ]
+    `);
   });
 
   test("can create dynamic token function", () => {

--- a/src/__tests__/rulesets.spec.tsx
+++ b/src/__tests__/rulesets.spec.tsx
@@ -13,7 +13,7 @@ describe("rulesets", () => {
     };
     const { getByTestId } = render(<Test />);
     const div = getByTestId("div");
-    expect(div.classList).toContain("TA572bd");
+    expect(div.classList).toContain("TA25");
   });
 
   test("can apply using a custom class", () => {
@@ -88,7 +88,7 @@ describe("rulesets", () => {
     };
     const { getByTestId } = render(<Test $c="green" />);
     const div = getByTestId("div");
-    expect(div.style.getPropertyValue("--TAe95be848-0")).toBe("green");
+    expect(div.style.getPropertyValue("--TA92ac1cc6-0")).toBe("green");
   });
 
   it("handles subselectors", async () => {

--- a/src/__tests__/rulesets.spec.tsx
+++ b/src/__tests__/rulesets.spec.tsx
@@ -13,7 +13,11 @@ describe("rulesets", () => {
     };
     const { getByTestId } = render(<Test />);
     const div = getByTestId("div");
-    expect(div.classList).toContain("TA25");
+    expect(div.classList).toMatchInlineSnapshot(`
+      DOMTokenList {
+        "0": "TA572bd",
+      }
+    `);
   });
 
   test("can apply using a custom class", () => {
@@ -88,7 +92,9 @@ describe("rulesets", () => {
     };
     const { getByTestId } = render(<Test $c="green" />);
     const div = getByTestId("div");
-    expect(div.style.getPropertyValue("--TA92ac1cc6-0")).toBe("green");
+    expect(div.getAttribute("style")).toMatchInlineSnapshot(
+      `"--TAc84292d5-0: green;"`
+    );
   });
 
   it("handles subselectors", async () => {

--- a/src/__tests__/rulesets.spec.tsx
+++ b/src/__tests__/rulesets.spec.tsx
@@ -88,7 +88,7 @@ describe("rulesets", () => {
     };
     const { getByTestId } = render(<Test $c="green" />);
     const div = getByTestId("div");
-    expect(div.style.getPropertyValue("--TAc84292d5-0")).toBe("green");
+    expect(div.style.getPropertyValue("--TAe95be848-0")).toBe("green");
   });
 
   it("handles subselectors", async () => {

--- a/src/__tests__/sheet.server.spec.tsx
+++ b/src/__tests__/sheet.server.spec.tsx
@@ -14,8 +14,8 @@ describe("stylesheet", () => {
     styled.div({
       color: "green",
     });
-    expect(sheet.getStyleString()).toEqual(
-      ".TAa69a7a5.TA1f79d95 { color: green; }"
+    expect(sheet.getStyleString()).toMatchInlineSnapshot(
+      `".TAcf6141c7.TA212d7b4f { color: green; }"`
     );
   });
 

--- a/src/__tests__/sheet.server.spec.tsx
+++ b/src/__tests__/sheet.server.spec.tsx
@@ -15,7 +15,7 @@ describe("stylesheet", () => {
       color: "green",
     });
     expect(sheet.getStyleString()).toEqual(
-      ".TAcf6141c7.TA212d7b4f { color: green; }"
+      ".TAa69a7a5.TA1f79d95 { color: green; }"
     );
   });
 

--- a/src/__tests__/styled.spec.tsx
+++ b/src/__tests__/styled.spec.tsx
@@ -134,4 +134,11 @@ describe("styled", () => {
     const two = screen.getByText(/two/);
     expect(one.classList).not.toEqual(two.classList);
   });
+
+  it("should receive base class no matter what", () => {
+    const Test = styled.div();
+    render(<Test as="main">test</Test>);
+    const t = screen.getByText(/test/);
+    expect(t.classList).toContain("TA572bd");
+  });
 });

--- a/src/__tests__/styled.spec.tsx
+++ b/src/__tests__/styled.spec.tsx
@@ -61,7 +61,7 @@ describe("styled", () => {
     render(<Test />);
     const span = screen.getByTestId("span");
     expect(span.getAttribute("style")).toEqual(
-      "--TAc84292d5-0: 700; font-family: sans-serif;"
+      "--TA567b4b32-0: 700; font-family: sans-serif;"
     );
     expect(span.classList.contains("hello")).toBe(true);
     expect(span.style.fontFamily).toEqual("sans-serif");
@@ -109,7 +109,29 @@ describe("styled", () => {
       </SelectoStyle>
     );
     expect(sheet.rules).toContain(
-      ".TAf4af03ec.TA57efd h1 { color: var(--TAf4af03ec-0); }"
+      ".TA9c805232.TA57efd h1 { color: var(--TA9c805232-0); }"
     );
+  });
+
+  it("different conditions should have different classes", () => {
+    const Test = styled.div<{ $color?: string; $fontFamily?: string }>(
+      {
+        color: ({ $color }) => $color,
+        condition: ({ $color }) => $color != null,
+      },
+      {
+        fontFamily: ({ $fontFamily }) => $fontFamily,
+        condition: ({ $fontFamily }) => $fontFamily != null,
+      }
+    );
+    render(
+      <Test>
+        <Test $color="blue">one</Test>
+        <Test $fontFamily="cursive">two</Test>
+      </Test>
+    );
+    const one = screen.getByText(/one/);
+    const two = screen.getByText(/two/);
+    expect(one.classList).not.toEqual(two.classList);
   });
 });

--- a/src/__tests__/styled.spec.tsx
+++ b/src/__tests__/styled.spec.tsx
@@ -60,8 +60,8 @@ describe("styled", () => {
     );
     render(<Test />);
     const span = screen.getByTestId("span");
-    expect(span.getAttribute("style")).toEqual(
-      "--TAc91a82f0-0: 700; font-family: sans-serif;"
+    expect(span.getAttribute("style")).toMatchInlineSnapshot(
+      `"--TAc84292d5-0: 700; font-family: sans-serif;"`
     );
     expect(span.classList.contains("hello")).toBe(true);
     expect(span.style.fontFamily).toEqual("sans-serif");
@@ -92,7 +92,9 @@ describe("styled", () => {
         <h1>Test!</h1>
       </SelectoStyle>
     );
-    expect(sheet.rules).toContain(".TA1a183a5a.TA25 h1 { color: red; }");
+    expect(sheet.rules[1]).toMatchInlineSnapshot(
+      `".TA1788df28.TA57efd h1 { color: red; }"`
+    );
   });
 
   it("styles selectors with variable functions", async () => {
@@ -108,8 +110,8 @@ describe("styled", () => {
         <h1>Test!</h1>
       </SelectoStyle>
     );
-    expect(sheet.rules).toContain(
-      ".TA936e7ea4.TA25 h1 { color: var(--TA936e7ea4-0); }"
+    expect(sheet.rules[1]).toMatchInlineSnapshot(
+      `".TAf4af03ec.TA57efd h1 { color: var(--TAf4af03ec-0); }"`
     );
   });
 

--- a/src/__tests__/styled.spec.tsx
+++ b/src/__tests__/styled.spec.tsx
@@ -61,7 +61,7 @@ describe("styled", () => {
     render(<Test />);
     const span = screen.getByTestId("span");
     expect(span.getAttribute("style")).toEqual(
-      "--TA567b4b32-0: 700; font-family: sans-serif;"
+      "--TAc91a82f0-0: 700; font-family: sans-serif;"
     );
     expect(span.classList.contains("hello")).toBe(true);
     expect(span.style.fontFamily).toEqual("sans-serif");
@@ -92,7 +92,7 @@ describe("styled", () => {
         <h1>Test!</h1>
       </SelectoStyle>
     );
-    expect(sheet.rules).toContain(".TA1788df28.TA57efd h1 { color: red; }");
+    expect(sheet.rules).toContain(".TA1a183a5a.TA25 h1 { color: red; }");
   });
 
   it("styles selectors with variable functions", async () => {
@@ -109,7 +109,7 @@ describe("styled", () => {
       </SelectoStyle>
     );
     expect(sheet.rules).toContain(
-      ".TA9c805232.TA57efd h1 { color: var(--TA9c805232-0); }"
+      ".TA936e7ea4.TA25 h1 { color: var(--TA936e7ea4-0); }"
     );
   });
 
@@ -136,9 +136,9 @@ describe("styled", () => {
   });
 
   it("should receive base class no matter what", () => {
-    const Test = styled.div();
+    const Test = styled.div({});
     render(<Test as="main">test</Test>);
     const t = screen.getByText(/test/);
-    expect(t.classList).toContain("TA572bd");
+    expect(t.classList).toHaveLength(2);
   });
 });

--- a/src/createGlobalStyle.tsx
+++ b/src/createGlobalStyle.tsx
@@ -2,6 +2,9 @@ import { cssToString } from "./helpers";
 import { Selectors, StaticSelectors } from "./lib/types";
 import { useRules } from "./useRules";
 
+/**
+ * Resolve function values *without* css custom properties
+ */
 function resolveFnValues<I>(
   decl: Selectors<I>[string],
   props: I

--- a/src/createTokens.tsx
+++ b/src/createTokens.tsx
@@ -1,0 +1,48 @@
+// type V = { [key: string]: string | V };
+
+import { createGlobalStyle } from "./createGlobalStyle";
+import { cssToString } from "./helpers";
+import { useRules } from "./useRules";
+
+type Tokens<T> = T & {
+  toStyleObject: () => Record<string, string>;
+  Tokens: () => null;
+  createDynamicTokens: <X>(fn: (props: X) => T) => (props: X) => null;
+};
+
+export function createTokens<V extends object>(vars: V) {
+  let map = {};
+  let R = {} as Tokens<V>;
+  function setVars(obj: object, returnObj: object, keys: string[] = []) {
+    for (const key in obj) {
+      let curVal = obj[key],
+        curKeys = keys.concat(key);
+      if (typeof curVal === "string") {
+        let varName = `--${curKeys.join("-")}`;
+        map[varName] = curVal;
+        returnObj[key] = `var(${varName})`;
+      } else {
+        returnObj[key] = {};
+        setVars(curVal, returnObj[key], curKeys);
+      }
+    }
+  }
+  Object.setPrototypeOf(R, {
+    toStyleObject() {
+      return map;
+    },
+    Tokens: createGlobalStyle({ html: map }),
+    createDynamicTokens<T>(fn: (props: T) => V) {
+      function DynamicTokens(props: T) {
+        let rules: string[] = [
+          cssToString("html", createTokens(fn(props)).toStyleObject()),
+        ];
+        useRules(rules);
+        return null;
+      }
+      return DynamicTokens;
+    },
+  });
+  setVars(vars, R);
+  return R;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,8 +24,6 @@ export type Ruleset<T> = PropertiesWithFunction<T> &
     selectors?: { [k: string]: PropertiesWithFunction<T> };
   };
 
-export type VarMap = Record<string, (args: any) => string>;
-
 type Condition<Interface> = boolean | ((props: Interface) => boolean);
 export type ConditionsMap<Interface> = Map<
   Record<string, string>,

--- a/src/rulesets.ts
+++ b/src/rulesets.ts
@@ -9,7 +9,7 @@ import { sheet } from "./sheet";
 type VMAP<T> = Map<string, (props: T) => string>;
 
 export function rulesets<Interface>(...rulesets: Ruleset<Interface>[]) {
-  const baseClass = getUniqueClassName(JSON.stringify(rulesets));
+  const baseClass = getUniqueClassName(stringify(rulesets));
 
   // Prepare permanent html + classNamesObject
   let rules: string[] = []; // Static CSS
@@ -22,7 +22,7 @@ export function rulesets<Interface>(...rulesets: Ruleset<Interface>[]) {
     let { apply, condition, selectors, ...style } = rulesets[i];
 
     condition = condition ?? true;
-    apply = apply ?? { className: getUniqueClassName(JSON.stringify(style)) };
+    apply = apply ?? { className: getUniqueClassName(stringify(style)) };
 
     // future logic for applying this (class or att)
     conditions.set(apply, condition);
@@ -137,4 +137,14 @@ export function replaceFuncsWithVars<T>(
   }
 
   return r;
+}
+
+function stringify(o: object) {
+  return JSON.stringify(o, function (_key, value) {
+    if (typeof value === "function") {
+      return value.toString();
+    } else {
+      return value;
+    }
+  });
 }

--- a/src/rulesets.ts
+++ b/src/rulesets.ts
@@ -139,12 +139,13 @@ export function replaceFuncsWithVars<T>(
   return r;
 }
 
-function stringify(o: object) {
-  return JSON.stringify(o, function (_key, value) {
-    if (typeof value === "function") {
-      return value.toString();
-    } else {
-      return value;
-    }
-  });
+function stringify(data: object) {
+  let out = "";
+
+  for (let p in data) {
+    let val = data[p];
+    out += p + (typeof val == "object" ? stringify(data[p]) : data[p]);
+  }
+
+  return out;
 }

--- a/src/tonami.ts
+++ b/src/tonami.ts
@@ -1,4 +1,5 @@
 export { createGlobalStyle } from "./createGlobalStyle";
+export { createTokens } from "./createTokens";
 
 export { options } from "./lib/constants";
 export { styled } from "./styled";


### PR DESCRIPTION
Added an API for creating css custom vars. The idea is that you create custom vars from an object (typically a theme), and what you get back is an accessor for the properties that will be created. That accessor also has a built in dynamic creation function for cases where you need to change theme variables. It also has a built in static function for cases where you don't. The thinking is that if you don't want variables to be global then you would probably put them directly on an element in the tree. The reason for these other helpers is because in most frameworks the `html` tag isn't in the tree.

```tsx
import { useReducer } from "react";
import { createGlobalStyle, createTokens } from "tonami";

const light = {
  foreground: "black",
  background: "white"
};
const dark = {
  foreground: "white",
  background: "black"
};
const modes = { light, dark };
const theme = createTokens(light);
const { createDynamicTokens } = theme;
const DynamicTokens = createDynamicTokens<{ $mode: "light" | "dark" }>(
  ({ $mode }) => modes[$mode]
);

const Global = createGlobalStyle({
  html: { backgroundColor: theme.background, color: theme.foreground }
});

export default function App() {
  const [mode, toggleMode] = useReducer(
    (m) => (m === "light" ? "dark" : "light"),
    "light"
  );
  return (
    <div className="App">
      <DynamicTokens $mode={mode} />
      <Global />
      <button onClick={toggleMode}>Toggle Theme</button>
      <h1>Hello World</h1>
    </div>
  );
}

```